### PR TITLE
Logger configuration with custom formatter.

### DIFF
--- a/src/Serilog.Sinks.TextWriter/TextWriterLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.TextWriter/TextWriterLoggerConfigurationExtensions.cs
@@ -17,6 +17,7 @@ using System.IO;
 using Serilog.Configuration;
 using Serilog.Core;
 using Serilog.Events;
+using Serilog.Formatting;
 using Serilog.Formatting.Display;
 using Serilog.Sinks.TextWriter;
 
@@ -30,7 +31,7 @@ namespace Serilog
         const string DefaultOutputTemplate = "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level}] {Message}{NewLine}{Exception}";
 
         /// <summary>
-        /// Write log events to the provided <see cref="TextWriter"/>.
+        /// Write log events to the provided <see cref="System.IO.TextWriter"/>.
         /// </summary>
         /// <param name="sinkConfiguration">Logger sink configuration.</param>
         /// <param name="textWriter">The text writer to write log events to.</param>
@@ -55,6 +56,31 @@ namespace Serilog
 
             var formatter = new MessageTemplateTextFormatter(outputTemplate, formatProvider);
             var sink = new TextWriterSink(textWriter, formatter);
+            return sinkConfiguration.Sink(sink, restrictedToMinimumLevel, levelSwitch);
+        }
+
+        /// <summary>
+        /// Write log events to the provided <see cref="System.IO.TextWriter"/>.
+        /// </summary>
+        /// <param name="sinkConfiguration">Logger sink configuration.</param>
+        /// <param name="textWriter">The text writer to write log events to.</param>
+        /// <param name="textFormatter">Text formatter used by sink.</param>
+        /// /// <param name="restrictedToMinimumLevel">The minimum level for
+        /// events passed through the sink. Ignored when <paramref name="levelSwitch"/> is specified.</param>
+        /// <param name="levelSwitch">A switch allowing the pass-through minimum level
+        /// to be changed at runtime.</param>
+        /// <exception cref="ArgumentNullException"></exception>
+        public static LoggerConfiguration TextWriter(
+            this LoggerSinkConfiguration sinkConfiguration,
+            TextWriter textWriter,
+            ITextFormatter textFormatter,
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+            LoggingLevelSwitch levelSwitch = null)
+        {
+            if (textWriter == null) throw new ArgumentNullException(nameof(textWriter));
+            if (textFormatter == null) throw new ArgumentNullException(nameof(textFormatter));
+
+            var sink = new TextWriterSink(textWriter, textFormatter);
             return sinkConfiguration.Sink(sink, restrictedToMinimumLevel, levelSwitch);
         }
     }

--- a/src/Serilog.Sinks.TextWriter/TextWriterLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.TextWriter/TextWriterLoggerConfigurationExtensions.cs
@@ -64,7 +64,7 @@ namespace Serilog
         /// </summary>
         /// <param name="sinkConfiguration">Logger sink configuration.</param>
         /// <param name="textWriter">The text writer to write log events to.</param>
-        /// <param name="textFormatter">Text formatter used by sink.</param>
+        /// <param name="formatter">Text formatter used by sink.</param>
         /// /// <param name="restrictedToMinimumLevel">The minimum level for
         /// events passed through the sink. Ignored when <paramref name="levelSwitch"/> is specified.</param>
         /// <param name="levelSwitch">A switch allowing the pass-through minimum level
@@ -72,15 +72,15 @@ namespace Serilog
         /// <exception cref="ArgumentNullException"></exception>
         public static LoggerConfiguration TextWriter(
             this LoggerSinkConfiguration sinkConfiguration,
+            ITextFormatter formatter,
             TextWriter textWriter,
-            ITextFormatter textFormatter,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             LoggingLevelSwitch levelSwitch = null)
         {
             if (textWriter == null) throw new ArgumentNullException(nameof(textWriter));
-            if (textFormatter == null) throw new ArgumentNullException(nameof(textFormatter));
+            if (formatter == null) throw new ArgumentNullException(nameof(formatter));
 
-            var sink = new TextWriterSink(textWriter, textFormatter);
+            var sink = new TextWriterSink(textWriter, formatter);
             return sinkConfiguration.Sink(sink, restrictedToMinimumLevel, levelSwitch);
         }
     }

--- a/test/Serilog.Tests/Sinks/TextWriter/TextWriterSinkTests.cs
+++ b/test/Serilog.Tests/Sinks/TextWriter/TextWriterSinkTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Globalization;
 using System.IO;
+using Serilog.Formatting.Display;
 using Xunit;
 using Serilog.Tests.Support;
 
@@ -32,6 +33,41 @@ namespace Serilog.Tests.Sinks.TextWriter
             var french = new CultureInfo("fr-FR");
             var log = new LoggerConfiguration()
                 .WriteTo.TextWriter(sw, formatProvider: french)
+                .CreateLogger();
+
+            var mt = String.Format(french, "{0}", 12.345);
+            log.Information("{0}", 12.345);
+
+            var s = sw.ToString();
+            Assert.True(s.Contains(mt));
+        }
+
+        [Fact]
+        public void CustomFormatter_EventsAreWrittenToTheTextWriter()
+        {
+            var sw = new StringWriter();
+
+            var formatter = new MessageTemplateTextFormatter("{Message}", null);
+            var log = new LoggerConfiguration()
+                .WriteTo.TextWriter(sw, formatter)
+                .CreateLogger();
+
+            var mt = Some.String();
+            log.Information(mt);
+
+            var s = sw.ToString();
+            Assert.True(s.Contains(mt));
+        }
+
+        [Fact]
+        public void CustomFormatter_EventsAreWrittenToTheTextWriterUsingFormatProvider()
+        {
+            var sw = new StringWriter();
+
+            var french = new CultureInfo("fr-FR");
+            var formatter = new MessageTemplateTextFormatter("{Message}", french);
+            var log = new LoggerConfiguration()
+                .WriteTo.TextWriter(sw, formatter)
                 .CreateLogger();
 
             var mt = String.Format(french, "{0}", 12.345);

--- a/test/Serilog.Tests/Sinks/TextWriter/TextWriterSinkTests.cs
+++ b/test/Serilog.Tests/Sinks/TextWriter/TextWriterSinkTests.cs
@@ -49,7 +49,7 @@ namespace Serilog.Tests.Sinks.TextWriter
 
             var formatter = new MessageTemplateTextFormatter("{Message}", null);
             var log = new LoggerConfiguration()
-                .WriteTo.TextWriter(sw, formatter)
+                .WriteTo.TextWriter(formatter, sw)
                 .CreateLogger();
 
             var mt = Some.String();
@@ -67,7 +67,7 @@ namespace Serilog.Tests.Sinks.TextWriter
             var french = new CultureInfo("fr-FR");
             var formatter = new MessageTemplateTextFormatter("{Message}", french);
             var log = new LoggerConfiguration()
-                .WriteTo.TextWriter(sw, formatter)
+                .WriteTo.TextWriter(formatter, sw)
                 .CreateLogger();
 
             var mt = String.Format(french, "{0}", 12.345);


### PR DESCRIPTION
TextWriter sink is perfect for unit tests. However, not being able to provide custom formatter is limiting.
For example you cannot test your JSON output. 
PR contains one more extension method that allows user provide custom formatter and appropriate tests.
